### PR TITLE
Allow node versions > 12.16

### DIFF
--- a/client/irving/package.json
+++ b/client/irving/package.json
@@ -11,7 +11,7 @@
     "predev": "npx check-node-version --package"
   },
   "engines": {
-    "node": "12.16.x"
+    "node": "12"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Updates the `engines` property in `package.json` to allow for later versions of Node 12.