### PR TITLE
Update site menu location

### DIFF
--- a/template-parts/header-default.json
+++ b/template-parts/header-default.json
@@ -51,7 +51,7 @@
       {
         "name": "irving/site-menu",
         "config": {
-          "location": "secondary"
+          "location": "primary"
         }
       }
     ]


### PR DESCRIPTION
This updates the location of the menu used in the default header to "primary" rather than "secondary" which isn't a registered menu location.